### PR TITLE
OneDrive API no longer provides email and modification date, and fixes for #1

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -59,8 +59,8 @@ transform.downloadFile = function(download_response){
 
 transform.getFileInformation = function (file_response){
     var transform = {};
-    transform.is_file = (file_response.type != "folder");
-    transform.is_folder = (file_response.type == "folder");
+    transform.is_file = true;
+    transform.is_folder = false;
     transform.etag = '';
     transform.identifier = file_response.id;
     transform.parent_identifier = file_response.parent_id;
@@ -102,8 +102,8 @@ transform.deleteFolder = function(deletion_response){
 
 transform.getFolderInformation = function(folder_response){
     var transform = {};
-    transform.is_file = (folder_response.type != "folder");
-    transform.is_folder = (folder_response.type == "folder");
+    transform.is_file = false;
+    transform.is_folder = true;
     transform.etag = '';
     transform.identifier = folder_response.id;
     transform.parent_identifier = folder_response.parent_id;
@@ -121,7 +121,7 @@ transform.retrieveFolderItems = function(items_response){
     var transform = {};
     transform.total_items = null;
     transform.content = items_response.data.map(function(current_item){
-        if(current_item.type != "folder"){
+        if(current_item.type != "folder" && current_item.type != "album"){
             return self.getFileInformation(current_item);
         }
         else{

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -4,10 +4,10 @@ var transform = {};
 transform.accountInfo = function(account_response){
     var transform = {};
     transform.name = account_response.name;
-    transform.email = account_response.emails.preferred;
+    transform.email = '';
     transform.avatar_url = '';
-    transform.created_date = new Date(account_response.updated_time);
-    transform.modified_date = new Date(account_response.updated_time);
+    transform.created_date = null;
+    transform.modified_date = null;
     transform.id = account_response.id;
     transform._raw = account_response;
     return transform;


### PR DESCRIPTION
The transformer for account informations is outdated and throws an error as it tries to access an undefined property, `account_response.email.preferred`.

The latest OneDrive API no longer returns email data nor modification date, see https://msdn.microsoft.com/EN-US/library/office/dn659736.aspx.

I fixed the `lib/transform.js` file to reflect those changes.
